### PR TITLE
Improve readability and add character count feature

### DIFF
--- a/SwiftCodeBattleHelper/ContentView.swift
+++ b/SwiftCodeBattleHelper/ContentView.swift
@@ -96,6 +96,7 @@ struct ContentView: View {
             if selectedFileURL != nil {
                 ScrollView {
                     Text(viewModel.fileContents)
+                        .font(.body.monospaced())
                         .frame(maxWidth: .infinity, alignment: .leading)
                         .padding()
                 }
@@ -113,6 +114,7 @@ struct ContentView: View {
                         deleteButton
                     }
                     TextEditor(text: $inputText)
+                        .font(.body.monospaced())
                         .padding()
                         .background(.background)
                         .border(Color.gray, width: 1)
@@ -128,6 +130,7 @@ struct ContentView: View {
                     }
                     ScrollView {
                         Text(viewModel.outputText)
+                            .font(.body.monospaced())
                             .frame(maxWidth: .infinity, alignment: .leading)
                             .padding()
                     }

--- a/SwiftCodeBattleHelper/ContentView.swift
+++ b/SwiftCodeBattleHelper/ContentView.swift
@@ -112,6 +112,8 @@ struct ContentView: View {
                         Text("stdin")
                         pasteButton
                         deleteButton
+                        Spacer()
+                        countText
                     }
                     TextEditor(text: $inputText)
                         .font(.body.monospaced())
@@ -140,6 +142,11 @@ struct ContentView: View {
             .frame(maxWidth: .infinity)
         }
         .padding()
+    }
+
+    @ViewBuilder
+    private var countText: some View {
+        Text("Char: \(viewModel.characterCount)")
     }
 
     @ViewBuilder

--- a/SwiftCodeBattleHelper/ContentView.swift
+++ b/SwiftCodeBattleHelper/ContentView.swift
@@ -101,6 +101,7 @@ struct ContentView: View {
                         .padding()
                 }
                 .frame(minHeight: 100)
+                .overlay(countText, alignment: .bottomTrailing)
                 .border(Color.gray, width: 1)
                 .padding(.vertical)
             } else {
@@ -112,8 +113,6 @@ struct ContentView: View {
                         Text("stdin")
                         pasteButton
                         deleteButton
-                        Spacer()
-                        countText
                     }
                     TextEditor(text: $inputText)
                         .font(.body.monospaced())
@@ -146,7 +145,9 @@ struct ContentView: View {
 
     @ViewBuilder
     private var countText: some View {
-        Text("Char: \(viewModel.characterCount)")
+        Text("count: \(viewModel.characterCount)")
+            .foregroundStyle(.secondary)
+            .padding()
     }
 
     @ViewBuilder

--- a/SwiftCodeBattleHelper/ViewModel.swift
+++ b/SwiftCodeBattleHelper/ViewModel.swift
@@ -123,10 +123,13 @@ final class ViewModel: ObservableObject {
     private func loadFiles() {
         guard let directoryURL else { return }
         do {
-            files = try fileManager.contentsOfDirectory(at: directoryURL, includingPropertiesForKeys: nil)
-                .sorted(by: { a, _ in
+            files = try fileManager.contentsOfDirectory(at: directoryURL, includingPropertiesForKeys: [])
+                .filter {
+                    $0.pathExtension == "swift"
+                }
+                .sorted { a, _ in
                     !a.lastPathComponent.hasPrefix(".")
-                })
+                }
         } catch {
             print("ディレクトリの読み込みに失敗しました: \(error)")
         }

--- a/SwiftCodeBattleHelper/ViewModel.swift
+++ b/SwiftCodeBattleHelper/ViewModel.swift
@@ -137,7 +137,7 @@ final class ViewModel: ObservableObject {
             fileContents = try String(contentsOf: selectedFileURL, encoding: .utf8)
             characterCount = countNonWhitespaceCharacters(fileContents)
         } catch {
-            if (error as NSError).code != 260 {
+            if (error as NSError).code != NSFileReadNoSuchFileError {
                 fileContents = "ファイルの読み込みに失敗しました: \(error)"
                 characterCount = 0
             }

--- a/SwiftCodeBattleHelper/ViewModel.swift
+++ b/SwiftCodeBattleHelper/ViewModel.swift
@@ -8,6 +8,7 @@ final class ViewModel: ObservableObject {
     @Published var files: [URL] = []
     @Published var isCopySuccessfulStateVisible = false
     @Published private(set) var commandStatus: Int32?
+    @Published private(set) var characterCount: Int = 0
     private var source: DispatchSourceFileSystemObject? = nil
     private let fileManager = FileManager.default
     private var directoryURL: URL?
@@ -134,11 +135,22 @@ final class ViewModel: ObservableObject {
     private func loadFileContents(selectedFileURL: URL) {
         do {
             fileContents = try String(contentsOf: selectedFileURL, encoding: .utf8)
+            characterCount = countNonWhitespaceCharacters(fileContents)
         } catch {
             if (error as NSError).code != 260 {
                 fileContents = "ファイルの読み込みに失敗しました: \(error)"
+                characterCount = 0
             }
         }
+    }
+
+    private func countNonWhitespaceCharacters(_ content: String) -> Int {
+        content.filter {
+            !$0.unicodeScalars.allSatisfy {
+                CharacterSet.whitespacesAndNewlines.contains($0)
+            }
+        }
+        .count
     }
 
     private func monitorFileChanges() {


### PR DESCRIPTION
1. use monospace font in text area.
2. automatically count non-whitespace characters of current file.
3. use `NSFileReadNoSuchFileError` instead of magic number 260.
4. filter swift file in file list.